### PR TITLE
Fix translation for 'remove' as 'eliminar',

### DIFF
--- a/es-ES.json
+++ b/es-ES.json
@@ -28,7 +28,7 @@
 	"SEARCH_EXPLANATION_PEOPLE": "Busca por actores, directores y escritores",
 	"SEARCH_PASTE_LINKS": "Pegar un enlace o enlace magnético",
 	"ADD_TO_LIB": "Añadir a la biblioteca",
-	"REMOVE_FROM_LIB": "Remover de la biblioteca",
+	"REMOVE_FROM_LIB": "Eliminar de la biblioteca",
 	"ADDED_TO_LIB": "Añadido a la biblioteca",
 	"REMOVED_FROM_LIB": "Eliminado de la biblioteca",
 	"TRAILER": "Avance",


### PR DESCRIPTION
Now, it really meaning 'delete', the previous translation 'remover' means 'shake' in spanish.

@lvshti could you have a look, please?