### PR TITLE
add-all.bat updates only the translation files and not package-lock.json

### DIFF
--- a/scripts/add-all.bat
+++ b/scripts/add-all.bat
@@ -1,2 +1,2 @@
 @echo off
-for %%f in (*-*.json) do call node scripts\add-missing-strings.js "%%f"
+for %%f in (??-??.json) do call node scripts\add-missing-strings.js "%%f"


### PR DESCRIPTION
I tested this with:
```
for %%f in (??-??.json) do echo "%%f"
```
And it printed all language files, but did not print the `package-lock.json` file, the previous `(*-*.json)` printed the `package-lock.json` file too.