### PR TITLE
"My" translation removed [pt-PT]

### DIFF
--- a/pt-PT.json
+++ b/pt-PT.json
@@ -1003,7 +1003,7 @@
 	"STREMIO_TV_WIFI_DETAILS_4": "stremiocircle",
 	"STREMIO_TV_WIFI_DETAILS_5": "Abrir o navegador com o link:",
 	"STREMIO_TV_DISCOVER_GENRE_DEFAULT": "Predefinido",
-	"STREMIO_TV_LIBRARY_MY": "Os meus / As minhas",
+	"STREMIO_TV_LIBRARY_MY": "",
 	"STREMIO_TV_LIBRARY_SORT_LAST_WATCHED": "Pela última vista",
 	"STREMIO_TV_LIBRARY_SORT_NAME": "Por nome",
 	"STREMIO_TV_LIBRARY_TIMES_WATCHED": "Por vezes vistas",


### PR DESCRIPTION
I removed the translation of "My" due to the problem of this being concatenated with movies or series in different situations. In Portuguese, movies is "filmes" a masculine word, so the translation would be "Os meus filmes" and for series, it would be "As minhas séries", since it is a feminine word. The previous translation of this string, that I did, was "Os meus / As minhas", but having into count that, in the case of Portuguese, "My" would have different translations depending on the word after, I think that in this situation, it's preferable to only have " Filmes" and " Séries" than "Os meus / As minhas Filmes" or "Os meus / As minhas Séries", since it gets more clear and simple.