### PR TITLE
Update nl-NL.json: "CAST"

### DIFF
--- a/nl-NL.json
+++ b/nl-NL.json
@@ -58,7 +58,7 @@
 	"DIRECTOR": "Regisseur",
 	"WRITER": "Schrijver",
 	"LEAD_ACTORS": "Hoofdrolspelers",
-	"CAST": "Rolverdeling",
+	"CAST": "Casten",
 	"CREW": "Crew",
 	"SHOW_MORE_CAST": "Laat meer zien »",
 	"AIRED": "Uitgezonden",


### PR DESCRIPTION
The term "Rolverdeling" was inaccurately used to describe casting content to devices. It has been updated to reflect the correct usage, as it traditionally pertains to the casting of actors in movies/series.