### PR TITLE
feat: add SKIP_INTRO key

### DIFF
--- a/ar-AR.json
+++ b/ar-AR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "الترجمة من {{origin}} مفعلة",
 	"PLAYER_PLAY": "تشغيل",
 	"PLAYER_PAUSE": "إيقاف",
+	"PLAYER_SKIP_INTRO": "تخطي المقدمة",
 	"PLAYER_NEXT_VIDEO": "الفيديو التالي",
 	"PLAYER_MUTE": "كتم الصوت",
 	"PLAYER_UNMUTE": "إلغاء الكتم",

--- a/be-BY.json
+++ b/be-BY.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтытры з {{origin}} загружаны",
 	"PLAYER_PLAY": "Прайграць",
 	"PLAYER_PAUSE": "Паўза",
+	"PLAYER_SKIP_INTRO": "Прапусціць уводзіны",
 	"PLAYER_NEXT_VIDEO": "Наступнае відэа",
 	"PLAYER_MUTE": "Выключыць гук",
 	"PLAYER_UNMUTE": "Уключыць гук",

--- a/bg-BG.json
+++ b/bg-BG.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитрите от {{origin}} са заредени",
 	"PLAYER_PLAY": "Пусни",
 	"PLAYER_PAUSE": "Пауза",
+	"PLAYER_SKIP_INTRO": "Пропусни интро",
 	"PLAYER_NEXT_VIDEO": "Следващо видео",
 	"PLAYER_MUTE": "Без звук",
 	"PLAYER_UNMUTE": "Пускане на звука",

--- a/bn-BD.json
+++ b/bn-BD.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}} থেকে সাবটাইটেল লোড হয়েছে",
 	"PLAYER_PLAY": "চালান",
 	"PLAYER_PAUSE": "বিরতি",
+	"PLAYER_SKIP_INTRO": "ইন্ট্রো এড়িয়ে যান",
 	"PLAYER_NEXT_VIDEO": "পরবর্তী ভিডিও",
 	"PLAYER_MUTE": "মিউট করুন",
 	"PLAYER_UNMUTE": "আনমিউট করুন",

--- a/ca-ES.json
+++ b/ca-ES.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtítols de {{origin}} carregats",
 	"PLAYER_PLAY": "Reprodueix",
 	"PLAYER_PAUSE": "Pausa",
+	"PLAYER_SKIP_INTRO": "Salta la introducció",
 	"PLAYER_NEXT_VIDEO": "Següent Vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Activar so",

--- a/cs-CZ.json
+++ b/cs-CZ.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titulky z {{origin}} načteny",
 	"PLAYER_PLAY": "Přehrát",
 	"PLAYER_PAUSE": "Pozastavit",
+	"PLAYER_SKIP_INTRO": "Přeskočit úvod",
 	"PLAYER_NEXT_VIDEO": "Další video",
 	"PLAYER_MUTE": "Ztlumit",
 	"PLAYER_UNMUTE": "Zrušit ztlumení",

--- a/da-DK.json
+++ b/da-DK.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Undertekster fra {{origin}} indlæst",
 	"PLAYER_PLAY": "Afspil",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Spring intro over",
 	"PLAYER_NEXT_VIDEO": "Næste Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/de-DE.json
+++ b/de-DE.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Untertitel von {{origin}} geladen",
 	"PLAYER_PLAY": "Abspielen",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Intro überspringen",
 	"PLAYER_NEXT_VIDEO": "Nächstes Video",
 	"PLAYER_MUTE": "Stummschalten",
 	"PLAYER_UNMUTE": "Ton einschalten",

--- a/el-GR.json
+++ b/el-GR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Οι υπότιτλοι από το {{origin}} φορτώθηκαν",
 	"PLAYER_PLAY": "Αναπαραγωγή",
 	"PLAYER_PAUSE": "Παύση",
+	"PLAYER_SKIP_INTRO": "Παράλειψη εισαγωγής",
 	"PLAYER_NEXT_VIDEO": "Επόμενο βίντεο",
 	"PLAYER_MUTE": "Σίγαση",
 	"PLAYER_UNMUTE": "Κατάργηση σίγασης",

--- a/en-US.json
+++ b/en-US.json
@@ -177,6 +177,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Skip Intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/eo-EO.json
+++ b/eo-EO.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Forpasi enkondukon",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/es-ES.json
+++ b/es-ES.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtítulos de {{origin}} cargados",
 	"PLAYER_PLAY": "Reproducir",
 	"PLAYER_PAUSE": "Pausar",
+	"PLAYER_SKIP_INTRO": "Saltar intro",
 	"PLAYER_NEXT_VIDEO": "Siguiente Vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Activar Sonido",

--- a/et-EE.json
+++ b/et-EE.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtiitrid allikast {{origin}} on laetud",
 	"PLAYER_PLAY": "Esita",
 	"PLAYER_PAUSE": "Peata",
+	"PLAYER_SKIP_INTRO": "Jäta intro vahele",
 	"PLAYER_NEXT_VIDEO": "Järgmine video",
 	"PLAYER_MUTE": "Vaigista",
 	"PLAYER_UNMUTE": "Tühista vaigistus",

--- a/eu-ES.json
+++ b/eu-ES.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}eko azpitituluak kargatuta",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Saltatu sarrera",
 	"PLAYER_NEXT_VIDEO": "Hurrengo bideoa",
 	"PLAYER_MUTE": "Mututu",
 	"PLAYER_UNMUTE": "Desmututu",

--- a/fa-IR.json
+++ b/fa-IR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "زیرنویس از {{origin}} بارگیری شد",
 	"PLAYER_PLAY": "پخش",
 	"PLAYER_PAUSE": "توقف",
+	"PLAYER_SKIP_INTRO": "رد کردن مقدمه",
 	"PLAYER_NEXT_VIDEO": "ویدیوی بعدی",
 	"PLAYER_MUTE": "بی صدا",
 	"PLAYER_UNMUTE": "باصدا کردن",

--- a/fi-FI.json
+++ b/fi-FI.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Tekstitykset lähteestä {{origin}} ladattu",
 	"PLAYER_PLAY": "Toista",
 	"PLAYER_PAUSE": "Tauko",
+	"PLAYER_SKIP_INTRO": "Ohita intro",
 	"PLAYER_NEXT_VIDEO": "Seuraava video",
 	"PLAYER_MUTE": "Mykistä",
 	"PLAYER_UNMUTE": "Poista mykistys",

--- a/fr-FR.json
+++ b/fr-FR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Sous-titres de {{origin}} chargés",
 	"PLAYER_PLAY": "Lecture",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Passer l'intro",
 	"PLAYER_NEXT_VIDEO": "Vidéo suivante",
 	"PLAYER_MUTE": "Sourdine",
 	"PLAYER_UNMUTE": "Rétablir le son",

--- a/he-IL.json
+++ b/he-IL.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "כתוביות מ-{{origin}} נטענו",
 	"PLAYER_PLAY": "ניגון",
 	"PLAYER_PAUSE": "הפסקה",
+	"PLAYER_SKIP_INTRO": "דלג על הפתיח",
 	"PLAYER_NEXT_VIDEO": "הוידאו הבא",
 	"PLAYER_MUTE": "השתקה",
 	"PLAYER_UNMUTE": "ביטול השתקה",

--- a/hi-IN.json
+++ b/hi-IN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "इंट्रो छोड़ें",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/hr-HR.json
+++ b/hr-HR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titlovi s {{origin}} su učitani",
 	"PLAYER_PLAY": "Reproduciraj",
 	"PLAYER_PAUSE": "Pauziraj",
+	"PLAYER_SKIP_INTRO": "Preskoči uvod",
 	"PLAYER_NEXT_VIDEO": "Sljedeći videozapis",
 	"PLAYER_MUTE": "Utišaj",
 	"PLAYER_UNMUTE": "Uključi zvuk",

--- a/hu-HU.json
+++ b/hu-HU.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Feliratok betöltve innen: {{origin}}",
 	"PLAYER_PLAY": "Lejátszás",
 	"PLAYER_PAUSE": "Szünet",
+	"PLAYER_SKIP_INTRO": "Intro átugrása",
 	"PLAYER_NEXT_VIDEO": "Következő Videó",
 	"PLAYER_MUTE": "Némítás",
 	"PLAYER_UNMUTE": "Némítás feloldása",

--- a/id-ID.json
+++ b/id-ID.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Takarir dari {{origin}} dimuat",
 	"PLAYER_PLAY": "Putar",
 	"PLAYER_PAUSE": "Jeda",
+	"PLAYER_SKIP_INTRO": "Lewati intro",
 	"PLAYER_NEXT_VIDEO": "Video Berikutnya",
 	"PLAYER_MUTE": "Bisukan",
 	"PLAYER_UNMUTE": "Bunyikan",

--- a/it-IT.json
+++ b/it-IT.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Sottotitoli da {{origin}} caricati",
 	"PLAYER_PLAY": "Riproduci",
 	"PLAYER_PAUSE": "Pausa",
+	"PLAYER_SKIP_INTRO": "Salta introduzione",
 	"PLAYER_NEXT_VIDEO": "Prossimo video",
 	"PLAYER_MUTE": "Muto",
 	"PLAYER_UNMUTE": "Non muto",

--- a/ja-JP.json
+++ b/ja-JP.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}からの字幕が読み込まれました",
 	"PLAYER_PLAY": "再生",
 	"PLAYER_PAUSE": "一時停止",
+	"PLAYER_SKIP_INTRO": "イントロをスキップ",
 	"PLAYER_NEXT_VIDEO": "次の動画",
 	"PLAYER_MUTE": "ミュート",
 	"PLAYER_UNMUTE": "ミュート解除",

--- a/ko-KR.json
+++ b/ko-KR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "인트로 건너뛰기",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/lt-LT.json
+++ b/lt-LT.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitrai iš {{origin}} įkelti",
 	"PLAYER_PLAY": "Leisti",
 	"PLAYER_PAUSE": "Sustabdyti",
+	"PLAYER_SKIP_INTRO": "Praleisti įžangą",
 	"PLAYER_NEXT_VIDEO": "Kitas Vaizdo Įrašas",
 	"PLAYER_MUTE": "Nutildyti",
 	"PLAYER_UNMUTE": "Įjungti garsą",

--- a/mk-MK.json
+++ b/mk-MK.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Преводите од {{origin}} се вчитани",
 	"PLAYER_PLAY": "Пушти",
 	"PLAYER_PAUSE": "Пауза",
+	"PLAYER_SKIP_INTRO": "Прескокни интро",
 	"PLAYER_NEXT_VIDEO": "Следно видео",
 	"PLAYER_MUTE": "Исклучи звук",
 	"PLAYER_UNMUTE": "Вклучи звук",

--- a/my-BM.json
+++ b/my-BM.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Skip Intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/nb-NO.json
+++ b/nb-NO.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Hopp over intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/ne-NP.json
+++ b/ne-NP.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Skip Intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/nl-NL.json
+++ b/nl-NL.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Ondertitelingen van {{origin}} geladen",
 	"PLAYER_PLAY": "Afspelen",
 	"PLAYER_PAUSE": "Pauzeren",
+	"PLAYER_SKIP_INTRO": "Intro overslaan",
 	"PLAYER_NEXT_VIDEO": "Volgende video",
 	"PLAYER_MUTE": "Dempen",
 	"PLAYER_UNMUTE": "Dempen uitschakelen",

--- a/nn-NO.json
+++ b/nn-NO.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Hopp over intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/pa-IN.json
+++ b/pa-IN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Skip Intro",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/pl-PL.json
+++ b/pl-PL.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Napisy z {{origin}} załadowane",
 	"PLAYER_PLAY": "Odtwarzaj",
 	"PLAYER_PAUSE": "Zatrzymaj",
+	"PLAYER_SKIP_INTRO": "Pomiń intro",
 	"PLAYER_NEXT_VIDEO": "Następne Wideo",
 	"PLAYER_MUTE": "Wycisz",
 	"PLAYER_UNMUTE": "Wyłącz wyciszenie",

--- a/pt-BR.json
+++ b/pt-BR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Legendas de {{origin}} carregadas",
 	"PLAYER_PLAY": "Reproduzir",
 	"PLAYER_PAUSE": "Pausar",
+	"PLAYER_SKIP_INTRO": "Pular introdução",
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",
 	"PLAYER_MUTE": "Mudo",
 	"PLAYER_UNMUTE": "Som",

--- a/pt-PT.json
+++ b/pt-PT.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Legendas de {{origin}} carregadas",
 	"PLAYER_PLAY": "Reproduzir",
 	"PLAYER_PAUSE": "Colocar em pausa",
+	"PLAYER_SKIP_INTRO": "Saltar introdução",
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Ativar som",

--- a/ro-RO.json
+++ b/ro-RO.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitrări de la {{origin}} încărcate",
 	"PLAYER_PLAY": "Redare",
 	"PLAYER_PAUSE": "Pauză",
+	"PLAYER_SKIP_INTRO": "Omite introul",
 	"PLAYER_NEXT_VIDEO": "Următorul videoclip",
 	"PLAYER_MUTE": "Dezactivare sunet",
 	"PLAYER_UNMUTE": "Activare sunet",

--- a/ru-RU.json
+++ b/ru-RU.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитры от {{origin}} загружены",
 	"PLAYER_PLAY": "Запуск",
 	"PLAYER_PAUSE": "Пауза",
+	"PLAYER_SKIP_INTRO": "Пропустить заставку",
 	"PLAYER_NEXT_VIDEO": "Следующее видео",
 	"PLAYER_MUTE": "Выкл. звук",
 	"PLAYER_UNMUTE": "Вкл. звук",

--- a/sk-SK.json
+++ b/sk-SK.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titulky z {{origin}} načítané",
 	"PLAYER_PLAY": "Prehrať",
 	"PLAYER_PAUSE": "Pozastaviť",
+	"PLAYER_SKIP_INTRO": "Preskočiť úvod",
 	"PLAYER_NEXT_VIDEO": "Ďalšie video",
 	"PLAYER_MUTE": "Stlmiť",
 	"PLAYER_UNMUTE": "Zrušiť stlmenie",

--- a/sl-SL.json
+++ b/sl-SL.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "Preskoči uvod",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/sr-RS.json
+++ b/sr-RS.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Учитани су титлови из {{origin}}",
 	"PLAYER_PLAY": "Пусти",
 	"PLAYER_PAUSE": "Паузирај",
+	"PLAYER_SKIP_INTRO": "Прескочи увод",
 	"PLAYER_NEXT_VIDEO": "Следећи видео снимак",
 	"PLAYER_MUTE": "Искључи звук",
 	"PLAYER_UNMUTE": "Укључи звук",

--- a/sv-SE.json
+++ b/sv-SE.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Undertexter från {{origin}} laddade",
 	"PLAYER_PLAY": "Spela",
 	"PLAYER_PAUSE": "Pausa",
+	"PLAYER_SKIP_INTRO": "Hoppa över intro",
 	"PLAYER_NEXT_VIDEO": "Nästa video",
 	"PLAYER_MUTE": "Slå av ljudet",
 	"PLAYER_UNMUTE": "Slå på ljudet",

--- a/ta-IN.json
+++ b/ta-IN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}-லிருந்து வசனங்கள் ஏற்றப்பட்டன",
 	"PLAYER_PLAY": "இயக்கு",
 	"PLAYER_PAUSE": "இடைநிறுத்து",
+	"PLAYER_SKIP_INTRO": "தொடக்கத்தைத் தவிர்",
 	"PLAYER_NEXT_VIDEO": "அடுத்த காணொலி",
 	"PLAYER_MUTE": "ஒலியை நிறுத்து",
 	"PLAYER_UNMUTE": "ஒலியை இயக்கு",

--- a/te-IN.json
+++ b/te-IN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
+	"PLAYER_SKIP_INTRO": "ఇంట్రో దాటవేయి",
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",

--- a/tr-TR.json
+++ b/tr-TR.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Altyazılar, {{origin}} kaynağından yüklendi",
 	"PLAYER_PLAY": "Oynat",
 	"PLAYER_PAUSE": "Duraklat",
+	"PLAYER_SKIP_INTRO": "İntroyu atla",
 	"PLAYER_NEXT_VIDEO": "Sonraki Görüntü",
 	"PLAYER_MUTE": "Sesi Kapat",
 	"PLAYER_UNMUTE": "Sesi Aç",

--- a/uk-UA.json
+++ b/uk-UA.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитри завантажено з {{origin}}",
 	"PLAYER_PLAY": "Грати",
 	"PLAYER_PAUSE": "Пауза",
+	"PLAYER_SKIP_INTRO": "Пропустити заставку",
 	"PLAYER_NEXT_VIDEO": "Наступне відео",
 	"PLAYER_MUTE": "Вимкнути звук",
 	"PLAYER_UNMUTE": "Увімкнути звук",

--- a/ur-PK.json
+++ b/ur-PK.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}} سے سب ٹائٹل لوڈ ہو گئے",
 	"PLAYER_PLAY": "چلائیں",
 	"PLAYER_PAUSE": "روکیں",
+	"PLAYER_SKIP_INTRO": "تعارف چھوڑیں",
 	"PLAYER_NEXT_VIDEO": "اگلا ویڈیو",
 	"PLAYER_MUTE": "آواز بند کریں",
 	"PLAYER_UNMUTE": "آواز چالو کریں",

--- a/vi-VN.json
+++ b/vi-VN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Đã tải phụ đề từ {{origin}}",
 	"PLAYER_PLAY": "Phát",
 	"PLAYER_PAUSE": "Tạm ngừng",
+	"PLAYER_SKIP_INTRO": "Bỏ qua mở đầu",
 	"PLAYER_NEXT_VIDEO": "Video tiếp theo",
 	"PLAYER_MUTE": "Tắt tiếng",
 	"PLAYER_UNMUTE": "Bật tiếng",

--- a/zh-CN.json
+++ b/zh-CN.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已加载{{origin}}字幕",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暂停",
+	"PLAYER_SKIP_INTRO": "跳过片头",
 	"PLAYER_NEXT_VIDEO": "下一个视频",
 	"PLAYER_MUTE": "静音",
 	"PLAYER_UNMUTE": "取消静音",

--- a/zh-HK.json
+++ b/zh-HK.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已加載{{origin}}字幕",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暫停",
+	"PLAYER_SKIP_INTRO": "略過片頭",
 	"PLAYER_NEXT_VIDEO": "下一個視頻",
 	"PLAYER_MUTE": "靜音",
 	"PLAYER_UNMUTE": "取消靜音",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -161,6 +161,7 @@
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已載入{{origin}}字幕",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暫停",
+	"PLAYER_SKIP_INTRO": "略過片頭",
 	"PLAYER_NEXT_VIDEO": "下一個影片",
 	"PLAYER_MUTE": "靜音",
 	"PLAYER_UNMUTE": "取消靜音",


### PR DESCRIPTION
This PR adds the missing SKIP_INTRO translation key to the i18n resource files across all supported languages.

Context

This key is required for upcoming UI work related to playback segment controls (intro skipping feature).

All language translations are already provided and aligned.

Changes
Added SKIP_INTRO key to translation dictionaries
No changes to existing translations
No behavior changes in the application
Impact
Enables consistent labeling of the “Skip Intro” action across all locales
Prepares UI layer for upcoming playback segment feature integration
Notes

This is a purely additive i18n change with no functional or UI impact on its own.