### PR TITLE
feat: add PLAYER_SUBTITLES_SECONDARY translation key

### DIFF
--- a/ar-AR.json
+++ b/ar-AR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "تم تفعيل الترجمة الحصرية",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "تم تفعيل الترجمة المحلية",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "الترجمة من {{origin}} مفعلة",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "تشغيل",
 	"PLAYER_PAUSE": "إيقاف",
 	"PLAYER_NEXT_VIDEO": "الفيديو التالي",

--- a/be-BY.json
+++ b/be-BY.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Эксклюзіўныя субтытры загружаны",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Лакальныя субтытры загружаны",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтытры з {{origin}} загружаны",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Прайграць",
 	"PLAYER_PAUSE": "Паўза",
 	"PLAYER_NEXT_VIDEO": "Наступнае відэа",

--- a/bg-BG.json
+++ b/bg-BG.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Ексклузивните субтитри са заредени",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Локалните субтитри са заредени",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитрите от {{origin}} са заредени",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Пусни",
 	"PLAYER_PAUSE": "Пауза",
 	"PLAYER_NEXT_VIDEO": "Следващо видео",

--- a/bn-BD.json
+++ b/bn-BD.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "এক্সক্লুসিভ সাবটাইটেল লোড হয়েছে",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "স্থানীয় সাবটাইটেল লোড হয়েছে",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}} থেকে সাবটাইটেল লোড হয়েছে",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "চালান",
 	"PLAYER_PAUSE": "বিরতি",
 	"PLAYER_NEXT_VIDEO": "পরবর্তী ভিডিও",

--- a/ca-ES.json
+++ b/ca-ES.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Subtítols exclusius carregats",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Subtítols locals carregats",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtítols de {{origin}} carregats",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Reprodueix",
 	"PLAYER_PAUSE": "Pausa",
 	"PLAYER_NEXT_VIDEO": "Següent Vídeo",

--- a/cs-CZ.json
+++ b/cs-CZ.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exkluzivní titulky načteny",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Místní titulky načteny",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titulky z {{origin}} načteny",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Přehrát",
 	"PLAYER_PAUSE": "Pozastavit",
 	"PLAYER_NEXT_VIDEO": "Další video",

--- a/da-DK.json
+++ b/da-DK.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Eksklusive undertekster indlæst",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Lokale undertekster indlæst",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Undertekster fra {{origin}} indlæst",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Afspil",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Næste Video",

--- a/de-DE.json
+++ b/de-DE.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exklusive Untertitel geladen",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Lokale Untertitel wurden geladen",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Untertitel von {{origin}} geladen",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Abspielen",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Nächstes Video",

--- a/el-GR.json
+++ b/el-GR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Οι ειδικοί υπότιτλοι φορτώθηκαν",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Οι τοπικοί υπότιτλοι φορτώθηκαν",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Οι υπότιτλοι από το {{origin}} φορτώθηκαν",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Αναπαραγωγή",
 	"PLAYER_PAUSE": "Παύση",
 	"PLAYER_NEXT_VIDEO": "Επόμενο βίντεο",

--- a/en-US.json
+++ b/en-US.json
@@ -175,6 +175,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/eo-EO.json
+++ b/eo-EO.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/es-ES.json
+++ b/es-ES.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Subtítulos exclusivos cargados",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Subtítulos locales cargados",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtítulos de {{origin}} cargados",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Reproducir",
 	"PLAYER_PAUSE": "Pausar",
 	"PLAYER_NEXT_VIDEO": "Siguiente Vídeo",

--- a/et-EE.json
+++ b/et-EE.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Eksklusiivsed subtiitrid on laetud",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtiitrid allikast {{origin}} on laetud",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Esita",
 	"PLAYER_PAUSE": "Peata",
 	"PLAYER_NEXT_VIDEO": "Järgmine video",

--- a/eu-ES.json
+++ b/eu-ES.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Azpitutulu esklusiboak kargatuta",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Azpitutuluen lokalak kargatuta",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}eko azpitituluak kargatuta",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Hurrengo bideoa",

--- a/fa-IR.json
+++ b/fa-IR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "زیرنویس انحصاری بارگذاری شد",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "زیرنویس محلی بارگذاری شد",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "زیرنویس از {{origin}} بارگیری شد",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "پخش",
 	"PLAYER_PAUSE": "توقف",
 	"PLAYER_NEXT_VIDEO": "ویدیوی بعدی",

--- a/fi-FI.json
+++ b/fi-FI.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Yksinoikeudella olevat tekstitykset ladattu",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Tekstitykset lähteestä {{origin}} ladattu",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Toista",
 	"PLAYER_PAUSE": "Tauko",
 	"PLAYER_NEXT_VIDEO": "Seuraava video",

--- a/fr-FR.json
+++ b/fr-FR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Sous-titres exclusifs chargés",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Sous-titres locaux chargés",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Sous-titres de {{origin}} chargés",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Lecture",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Vidéo suivante",

--- a/he-IL.json
+++ b/he-IL.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "כתוביות אקסלוסיביות נטענו",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "כתוביות מ-{{origin}} נטענו",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "ניגון",
 	"PLAYER_PAUSE": "הפסקה",
 	"PLAYER_NEXT_VIDEO": "הוידאו הבא",

--- a/hi-IN.json
+++ b/hi-IN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/hr-HR.json
+++ b/hr-HR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Ekskluzivni titlovi učitani",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Lokalni titlovi učitani",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titlovi s {{origin}} su učitani",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Reproduciraj",
 	"PLAYER_PAUSE": "Pauziraj",
 	"PLAYER_NEXT_VIDEO": "Sljedeći videozapis",

--- a/hu-HU.json
+++ b/hu-HU.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exkluzív feliratok betöltve",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Feliratok betöltve innen: {{origin}}",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Lejátszás",
 	"PLAYER_PAUSE": "Szünet",
 	"PLAYER_NEXT_VIDEO": "Következő Videó",

--- a/id-ID.json
+++ b/id-ID.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Takarir eksklusif dimuat",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Takarir dari {{origin}} dimuat",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Putar",
 	"PLAYER_PAUSE": "Jeda",
 	"PLAYER_NEXT_VIDEO": "Video Berikutnya",

--- a/it-IT.json
+++ b/it-IT.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Sottotitoli escusivi caricati",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Sottotitoli locali caricati",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Sottotitoli da {{origin}} caricati",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Riproduci",
 	"PLAYER_PAUSE": "Pausa",
 	"PLAYER_NEXT_VIDEO": "Prossimo video",

--- a/ja-JP.json
+++ b/ja-JP.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "独占的な字幕が読み込まれました",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}からの字幕が読み込まれました",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "再生",
 	"PLAYER_PAUSE": "一時停止",
 	"PLAYER_NEXT_VIDEO": "次の動画",

--- a/ko-KR.json
+++ b/ko-KR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/lt-LT.json
+++ b/lt-LT.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Išskirtiniai subtitrai įkelti",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Vietiniai subtitrai įkelti",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitrai iš {{origin}} įkelti",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Leisti",
 	"PLAYER_PAUSE": "Sustabdyti",
 	"PLAYER_NEXT_VIDEO": "Kitas Vaizdo Įrašas",

--- a/mk-MK.json
+++ b/mk-MK.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Вчитани се ексклузивни преводи",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Преводите од {{origin}} се вчитани",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Пушти",
 	"PLAYER_PAUSE": "Пауза",
 	"PLAYER_NEXT_VIDEO": "Следно видео",

--- a/my-BM.json
+++ b/my-BM.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/nb-NO.json
+++ b/nb-NO.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/ne-NP.json
+++ b/ne-NP.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/nl-NL.json
+++ b/nl-NL.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusieve ondertitelingen geladen",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Ondertitelingen van {{origin}} geladen",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Afspelen",
 	"PLAYER_PAUSE": "Pauzeren",
 	"PLAYER_NEXT_VIDEO": "Volgende video",

--- a/nn-NO.json
+++ b/nn-NO.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/pa-IN.json
+++ b/pa-IN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/pl-PL.json
+++ b/pl-PL.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Wczytano ekskluzywne  napisy",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Napisy z {{origin}} załadowane",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Odtwarzaj",
 	"PLAYER_PAUSE": "Zatrzymaj",
 	"PLAYER_NEXT_VIDEO": "Następne Wideo",

--- a/pt-BR.json
+++ b/pt-BR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Legendas exclusivas carregadas",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Legendas locais carregadas",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Legendas de {{origin}} carregadas",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Reproduzir",
 	"PLAYER_PAUSE": "Pausar",
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",

--- a/pt-PT.json
+++ b/pt-PT.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Legendas exclusivas carregadas",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Legendas locais carregadas",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Legendas de {{origin}} carregadas",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Reproduzir",
 	"PLAYER_PAUSE": "Colocar em pausa",
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",

--- a/ro-RO.json
+++ b/ro-RO.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Subtitrări exclusive încărcate",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitrări de la {{origin}} încărcate",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Redare",
 	"PLAYER_PAUSE": "Pauză",
 	"PLAYER_NEXT_VIDEO": "Următorul videoclip",

--- a/ru-RU.json
+++ b/ru-RU.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Эксклюзивные субтитры загружены",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Локальные субтитры загружены",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитры от {{origin}} загружены",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Запуск",
 	"PLAYER_PAUSE": "Пауза",
 	"PLAYER_NEXT_VIDEO": "Следующее видео",

--- a/sk-SK.json
+++ b/sk-SK.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exkluzívne titulky načítané",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Lokálne titulky načítané",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Titulky z {{origin}} načítané",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Prehrať",
 	"PLAYER_PAUSE": "Pozastaviť",
 	"PLAYER_NEXT_VIDEO": "Ďalšie video",

--- a/sl-SL.json
+++ b/sl-SL.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/sr-RS.json
+++ b/sr-RS.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Ексклузивни титлови су учитани",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Учитани су титлови из {{origin}}",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Пусти",
 	"PLAYER_PAUSE": "Паузирај",
 	"PLAYER_NEXT_VIDEO": "Следећи видео снимак",

--- a/sv-SE.json
+++ b/sv-SE.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exklusiva undertexter laddade",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Lokala undertexter laddade",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Undertexter från {{origin}} laddade",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Spela",
 	"PLAYER_PAUSE": "Pausa",
 	"PLAYER_NEXT_VIDEO": "Nästa video",

--- a/ta-IN.json
+++ b/ta-IN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "பிரத்தியேக வசனங்கள் ஏற்றப்பட்டன",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "உள்ளூர் வசனங்கள் ஏற்றப்பட்டன",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}}-லிருந்து வசனங்கள் ஏற்றப்பட்டன",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "இயக்கு",
 	"PLAYER_PAUSE": "இடைநிறுத்து",
 	"PLAYER_NEXT_VIDEO": "அடுத்த காணொலி",

--- a/te-IN.json
+++ b/te-IN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Exclusive subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Subtitles from {{origin}} loaded",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Play",
 	"PLAYER_PAUSE": "Pause",
 	"PLAYER_NEXT_VIDEO": "Next Video",

--- a/tr-TR.json
+++ b/tr-TR.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Özel altyazılar yüklendi",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Yerel altyazılar yüklendi",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Altyazılar, {{origin}} kaynağından yüklendi",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Oynat",
 	"PLAYER_PAUSE": "Duraklat",
 	"PLAYER_NEXT_VIDEO": "Sonraki Görüntü",

--- a/uk-UA.json
+++ b/uk-UA.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Ексклюзивні субтитри завантажено",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Субтитри завантажено з {{origin}}",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Грати",
 	"PLAYER_PAUSE": "Пауза",
 	"PLAYER_NEXT_VIDEO": "Наступне відео",

--- a/ur-PK.json
+++ b/ur-PK.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "خصوصی سب ٹائٹل لوڈ ہو گئے",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "مقامی سب ٹائٹل لوڈ ہو گئے",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "{{origin}} سے سب ٹائٹل لوڈ ہو گئے",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "چلائیں",
 	"PLAYER_PAUSE": "روکیں",
 	"PLAYER_NEXT_VIDEO": "اگلا ویڈیو",

--- a/vi-VN.json
+++ b/vi-VN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "Đã tải phụ đề độc quyền",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "Đã tải phụ đề từ {{origin}}",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "Phát",
 	"PLAYER_PAUSE": "Tạm ngừng",
 	"PLAYER_NEXT_VIDEO": "Video tiếp theo",

--- a/zh-CN.json
+++ b/zh-CN.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "已加载外部字幕",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已加载{{origin}}字幕",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暂停",
 	"PLAYER_NEXT_VIDEO": "下一个视频",

--- a/zh-HK.json
+++ b/zh-HK.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "已加載外部字幕",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已加載{{origin}}字幕",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暫停",
 	"PLAYER_NEXT_VIDEO": "下一個視頻",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -159,6 +159,7 @@
 	"PLAYER_SUBTITLES_LOADED_EXCLUSIVE": "已載入外部字幕",
 	"PLAYER_SUBTITLES_LOADED_LOCAL": "Local subtitles loaded",
 	"PLAYER_SUBTITLES_LOADED_ORIGIN": "已載入{{origin}}字幕",
+	"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle",
 	"PLAYER_PLAY": "播放",
 	"PLAYER_PAUSE": "暫停",
 	"PLAYER_NEXT_VIDEO": "下一個影片",


### PR DESCRIPTION
## Summary

Adds the `PLAYER_SUBTITLES_SECONDARY` translation key needed by the dual subtitle feature in stremio-web.

### Changes
- Added `"PLAYER_SUBTITLES_SECONDARY": "Secondary Subtitle"` to `en-US.json`
- Propagated to all 40+ locale files using existing `scripts/add-missing-strings.js`
- Community translators can update individual locale values later

### Testing
- All 51 locale integrity tests pass (key ordering + valid JSON)

### Related
- stremio-web: adds dual subtitle UI
- stremio-video: adds mpv secondary-sid bridge

### Related PRs
- stremio-video: https://github.com/Stremio/stremio-video/pull/146
- stremio-web: https://github.com/Stremio/stremio-web/pull/1286