### PR TITLE
Add Picture-in-Picture player labels

### DIFF
--- a/ar-AR.json
+++ b/ar-AR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "الفيديو التالي",
 	"PLAYER_MUTE": "كتم الصوت",
 	"PLAYER_UNMUTE": "إلغاء الكتم",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "الفتح في مشغل خارجي",
 	"PLAYER_OPEN_IN_NPLAYER": "فتح في nPlayer",
 	"PLAYER_PLAY_IN": "تشغيل في {{device}}",

--- a/be-BY.json
+++ b/be-BY.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Наступнае відэа",
 	"PLAYER_MUTE": "Выключыць гук",
 	"PLAYER_UNMUTE": "Уключыць гук",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Адкрыць у знешнім плэеры",
 	"PLAYER_OPEN_IN_NPLAYER": "Адкрыць у nPlayer",
 	"PLAYER_PLAY_IN": "Прайграць на {{device}}",

--- a/bg-BG.json
+++ b/bg-BG.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Следващо видео",
 	"PLAYER_MUTE": "Без звук",
 	"PLAYER_UNMUTE": "Пускане на звука",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Отваряне във външен плеър",
 	"PLAYER_OPEN_IN_NPLAYER": "Отваряне в nPlayer",
 	"PLAYER_PLAY_IN": "Пускане на {{device}}",

--- a/bn-BD.json
+++ b/bn-BD.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "পরবর্তী ভিডিও",
 	"PLAYER_MUTE": "মিউট করুন",
 	"PLAYER_UNMUTE": "আনমিউট করুন",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "বাহ্যিক প্লেয়ারে খুলুন",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayer-এ খুলুন",
 	"PLAYER_PLAY_IN": "{{device}}-এ চালান",

--- a/ca-ES.json
+++ b/ca-ES.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Següent Vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Activar so",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Obre en un reproductor extern",
 	"PLAYER_OPEN_IN_NPLAYER": "Obre en nPlayer",
 	"PLAYER_PLAY_IN": "Reprodueix a {{device}}",

--- a/cs-CZ.json
+++ b/cs-CZ.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Další video",
 	"PLAYER_MUTE": "Ztlumit",
 	"PLAYER_UNMUTE": "Zrušit ztlumení",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Otevřít v externím přehrávači",
 	"PLAYER_OPEN_IN_NPLAYER": "Otevřít v nPlayer",
 	"PLAYER_PLAY_IN": "Přehrát na {{device}}",

--- a/da-DK.json
+++ b/da-DK.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Næste video",
 	"PLAYER_MUTE": "Lydløs",
 	"PLAYER_UNMUTE": "Slå lyd til",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Åbn i ekstern afspiller",
 	"PLAYER_OPEN_IN_NPLAYER": "Åbn i nPlayer",
 	"PLAYER_PLAY_IN": "Afspil i {{device}}",

--- a/de-DE.json
+++ b/de-DE.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Nächstes Video",
 	"PLAYER_MUTE": "Stummschalten",
 	"PLAYER_UNMUTE": "Ton einschalten",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "In externem Player öffnen",
 	"PLAYER_OPEN_IN_NPLAYER": "In nPlayer öffnen",
 	"PLAYER_PLAY_IN": "Auf {{device}} abspielen",

--- a/el-GR.json
+++ b/el-GR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Επόμενο βίντεο",
 	"PLAYER_MUTE": "Σίγαση",
 	"PLAYER_UNMUTE": "Κατάργηση σίγασης",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Άνοιγμα σε εξωτερικό πρόγραμμα αναπαραγωγής",
 	"PLAYER_OPEN_IN_NPLAYER": "Άνοιγμα στον nPlayer",
 	"PLAYER_PLAY_IN": "Αναπαραγωγή στο {{device}}",

--- a/en-US.json
+++ b/en-US.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/eo-EO.json
+++ b/eo-EO.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/es-ES.json
+++ b/es-ES.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Siguiente Vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Activar Sonido",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Abrir en reproductor externo",
 	"PLAYER_OPEN_IN_NPLAYER": "Abrir en nPlayer",
 	"PLAYER_PLAY_IN": "Reproducir en {{device}}",

--- a/et-EE.json
+++ b/et-EE.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Järgmine video",
 	"PLAYER_MUTE": "Vaigista",
 	"PLAYER_UNMUTE": "Tühista vaigistus",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Ava välises esitajas",
 	"PLAYER_OPEN_IN_NPLAYER": "Ava nPlayeris",
 	"PLAYER_PLAY_IN": "Esita seadmes {{device}}",

--- a/eu-ES.json
+++ b/eu-ES.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Hurrengo bideoa",
 	"PLAYER_MUTE": "Mututu",
 	"PLAYER_UNMUTE": "Desmututu",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Kanpoko erreproduzitzailean ireki",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayer-en ireki",
 	"PLAYER_PLAY_IN": "{{device}}-en ireki",

--- a/fa-IR.json
+++ b/fa-IR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "ویدیوی بعدی",
 	"PLAYER_MUTE": "بی صدا",
 	"PLAYER_UNMUTE": "باصدا کردن",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "باز کردن در پخش کننده خارجی",
 	"PLAYER_OPEN_IN_NPLAYER": "باز کردن در nPlayer",
 	"PLAYER_PLAY_IN": "پخش در {{device}}",

--- a/fi-FI.json
+++ b/fi-FI.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Seuraava video",
 	"PLAYER_MUTE": "Mykistä",
 	"PLAYER_UNMUTE": "Poista mykistys",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Avaa ulkoisessa soittimessa",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Toista laitteessa {{device}}",

--- a/fr-FR.json
+++ b/fr-FR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Vidéo suivante",
 	"PLAYER_MUTE": "Sourdine",
 	"PLAYER_UNMUTE": "Rétablir le son",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Ouvrir dans un lecteur externe",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Jouer sur {{device}}",

--- a/he-IL.json
+++ b/he-IL.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "הוידאו הבא",
 	"PLAYER_MUTE": "השתקה",
 	"PLAYER_UNMUTE": "ביטול השתקה",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "פתח בנגן וידאו חיצוני",
 	"PLAYER_OPEN_IN_NPLAYER": "פתיחה בnPlayer",
 	"PLAYER_PLAY_IN": "נגן ב {{device}}",

--- a/hi-IN.json
+++ b/hi-IN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/hr-HR.json
+++ b/hr-HR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Sljedeći videozapis",
 	"PLAYER_MUTE": "Utišaj",
 	"PLAYER_UNMUTE": "Uključi zvuk",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Otvori u vanjskom playeru",
 	"PLAYER_OPEN_IN_NPLAYER": "Otvori u nPlayeru",
 	"PLAYER_PLAY_IN": "Reproduciraj na: {{device}}",

--- a/hu-HU.json
+++ b/hu-HU.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Következő Videó",
 	"PLAYER_MUTE": "Némítás",
 	"PLAYER_UNMUTE": "Némítás feloldása",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Megnyitás külső lejátszóban",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Lejátszás ezzel: {{device}}",

--- a/id-ID.json
+++ b/id-ID.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Video Berikutnya",
 	"PLAYER_MUTE": "Bisukan",
 	"PLAYER_UNMUTE": "Bunyikan",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Buka di pemutar eksternal",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Putar di {{device}}",

--- a/it-IT.json
+++ b/it-IT.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Prossimo video",
 	"PLAYER_MUTE": "Muto",
 	"PLAYER_UNMUTE": "Non muto",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Apri in un player esterno",
 	"PLAYER_OPEN_IN_NPLAYER": "Apri su nPlayer",
 	"PLAYER_PLAY_IN": "In riproduzione su {{device}}",

--- a/ja-JP.json
+++ b/ja-JP.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "次の動画",
 	"PLAYER_MUTE": "ミュート",
 	"PLAYER_UNMUTE": "ミュート解除",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "外部プレーヤーで開く",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayerで開く",
 	"PLAYER_PLAY_IN": "{{device}}で再生",

--- a/ko-KR.json
+++ b/ko-KR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/lt-LT.json
+++ b/lt-LT.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Kitas Vaizdo Įrašas",
 	"PLAYER_MUTE": "Nutildyti",
 	"PLAYER_UNMUTE": "Įjungti garsą",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Atidaryti išoriniame grotuve",
 	"PLAYER_OPEN_IN_NPLAYER": "Atidaryti su nPlayer",
 	"PLAYER_PLAY_IN": "Leisti įrenginyje {{device}}",

--- a/mk-MK.json
+++ b/mk-MK.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Следно видео",
 	"PLAYER_MUTE": "Исклучи звук",
 	"PLAYER_UNMUTE": "Вклучи звук",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Отворете во надворешен плеер",
 	"PLAYER_OPEN_IN_NPLAYER": "Отворете во nPlayer",
 	"PLAYER_PLAY_IN": "Пушти во {{device}}",

--- a/my-BM.json
+++ b/my-BM.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/nb-NO.json
+++ b/nb-NO.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/ne-NP.json
+++ b/ne-NP.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/nl-NL.json
+++ b/nl-NL.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Volgende video",
 	"PLAYER_MUTE": "Dempen",
 	"PLAYER_UNMUTE": "Dempen uitschakelen",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Openen in externe speler",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Afspelen op {{device}}",

--- a/nn-NO.json
+++ b/nn-NO.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/pa-IN.json
+++ b/pa-IN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/pl-PL.json
+++ b/pl-PL.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Następne Wideo",
 	"PLAYER_MUTE": "Wycisz",
 	"PLAYER_UNMUTE": "Wyłącz wyciszenie",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Otwórz w zewnętrznym odtwarzaczu",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Puść na {{device}}",

--- a/pt-BR.json
+++ b/pt-BR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",
 	"PLAYER_MUTE": "Mudo",
 	"PLAYER_UNMUTE": "Som",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Abrir em reprodutor externo",
 	"PLAYER_OPEN_IN_NPLAYER": "Abrir pelo nPlayer",
 	"PLAYER_PLAY_IN": "Reproduzir em {{device}}",

--- a/pt-PT.json
+++ b/pt-PT.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Próximo vídeo",
 	"PLAYER_MUTE": "Silenciar",
 	"PLAYER_UNMUTE": "Ativar som",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Abrir num leitor externo",
 	"PLAYER_OPEN_IN_NPLAYER": "Abrir no nPlayer",
 	"PLAYER_PLAY_IN": "Reproduzir no {{device}}",

--- a/ro-RO.json
+++ b/ro-RO.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Următorul videoclip",
 	"PLAYER_MUTE": "Dezactivare sunet",
 	"PLAYER_UNMUTE": "Activare sunet",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Deschide în player extern",
 	"PLAYER_OPEN_IN_NPLAYER": "Deschide în nPlayer",
 	"PLAYER_PLAY_IN": "Redă în {{device}}",

--- a/ru-RU.json
+++ b/ru-RU.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Следующее видео",
 	"PLAYER_MUTE": "Выкл. звук",
 	"PLAYER_UNMUTE": "Вкл. звук",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Открыть во внешнем проигрывателе",
 	"PLAYER_OPEN_IN_NPLAYER": "Открыть в nPlayer",
 	"PLAYER_PLAY_IN": "Запуск на {{device}}",

--- a/sk-SK.json
+++ b/sk-SK.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Ďalšie video",
 	"PLAYER_MUTE": "Stlmiť",
 	"PLAYER_UNMUTE": "Zrušiť stlmenie",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Otvoriť vo vonkajšom prehrávači",
 	"PLAYER_OPEN_IN_NPLAYER": "Otvoriť v nPlayeri",
 	"PLAYER_PLAY_IN": "Prehrať na {{device}}",

--- a/sl-SL.json
+++ b/sl-SL.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/sr-RS.json
+++ b/sr-RS.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Следећи видео снимак",
 	"PLAYER_MUTE": "Искључи звук",
 	"PLAYER_UNMUTE": "Укључи звук",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Отвори у спољном плејеру",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Пусти на {{device}}",

--- a/sv-SE.json
+++ b/sv-SE.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Nästa video",
 	"PLAYER_MUTE": "Slå av ljudet",
 	"PLAYER_UNMUTE": "Slå på ljudet",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Öppna i extern spelare",
 	"PLAYER_OPEN_IN_NPLAYER": "Öppna i nPlayer",
 	"PLAYER_PLAY_IN": "Spela på {{device}}",

--- a/ta-IN.json
+++ b/ta-IN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "அடுத்த காணொலி",
 	"PLAYER_MUTE": "ஒலியை நிறுத்து",
 	"PLAYER_UNMUTE": "ஒலியை இயக்கு",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "வெளிப்புற பிளேயரில் திற",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayer-ல் திற",
 	"PLAYER_PLAY_IN": "{{device}}-ல் இயக்கு",

--- a/te-IN.json
+++ b/te-IN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Next Video",
 	"PLAYER_MUTE": "Mute",
 	"PLAYER_UNMUTE": "Unmute",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Open in external player",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Play in {{device}}",

--- a/tr-TR.json
+++ b/tr-TR.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Sonraki Görüntü",
 	"PLAYER_MUTE": "Sesi Kapat",
 	"PLAYER_UNMUTE": "Sesi Aç",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Harici oynatıcıda aç",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayer'da aç",
 	"PLAYER_PLAY_IN": "{{device}} içinde oynat",

--- a/uk-UA.json
+++ b/uk-UA.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Наступне відео",
 	"PLAYER_MUTE": "Вимкнути звук",
 	"PLAYER_UNMUTE": "Увімкнути звук",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Відкрити у зовнішньому плеєрі",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Грати на {{device}}",

--- a/ur-PK.json
+++ b/ur-PK.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "اگلا ویڈیو",
 	"PLAYER_MUTE": "آواز بند کریں",
 	"PLAYER_UNMUTE": "آواز چالو کریں",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "بیرونی پلیئر میں کھولیں",
 	"PLAYER_OPEN_IN_NPLAYER": "nPlayer میں کھولیں",
 	"PLAYER_PLAY_IN": "{{device}} میں چلائیں",

--- a/vi-VN.json
+++ b/vi-VN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "Video tiếp theo",
 	"PLAYER_MUTE": "Tắt tiếng",
 	"PLAYER_UNMUTE": "Bật tiếng",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "Mở trong trình phát bên ngoài",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "Phát trên {{device}}",

--- a/zh-CN.json
+++ b/zh-CN.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "下一个视频",
 	"PLAYER_MUTE": "静音",
 	"PLAYER_UNMUTE": "取消静音",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "在外部播放器中打开",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "在{{device}}上播放",

--- a/zh-HK.json
+++ b/zh-HK.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "下一個視頻",
 	"PLAYER_MUTE": "靜音",
 	"PLAYER_UNMUTE": "取消靜音",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "在外部播放器中打開",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "在{{device}}上播放",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -176,6 +176,8 @@
 	"PLAYER_NEXT_VIDEO": "下一個影片",
 	"PLAYER_MUTE": "靜音",
 	"PLAYER_UNMUTE": "取消靜音",
+	"PLAYER_PICTURE_IN_PICTURE": "Picture-in-picture",
+	"PLAYER_EXIT_PICTURE_IN_PICTURE": "Exit picture-in-picture",
 	"PLAYER_OPEN_IN_EXTERNAL": "在外部播放器中開啟",
 	"PLAYER_OPEN_IN_NPLAYER": "Open in nPlayer",
 	"PLAYER_PLAY_IN": "在{{device}}上播放",


### PR DESCRIPTION
Adds the translation keys required by Stremio Web PR #1354:

- PLAYER_PICTURE_IN_PICTURE
- PLAYER_EXIT_PICTURE_IN_PICTURE

English fallback values are included for all locale files, matching the repository pattern.

Validation: npm test