### PR TITLE
Add SETTINGS_SERVER_CONFIGURE_CONFIRM

### DIFF
--- a/ar-AR.json
+++ b/ar-AR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "خطأ",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "تكوين عنوان لخادم البث",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "أدخل عنوان لخادم البث",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "حجم التخزين المؤقت",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "ملف التورنت التعريفي",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/be-BY.json
+++ b/be-BY.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Памылка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Наладзіць URL сервера струменевай перадачы",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Увядзіце URL сервера струменевай перадачы",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Памер кэшу",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Торэнт-профіль",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/bg-BG.json
+++ b/bg-BG.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Грешка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Конфигурирай URL на сървъра за поточно предаване",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Въведи URL на сървъра за поточно предаване",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Размер на кеша",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Торент профил",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/bn-BD.json
+++ b/bn-BD.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "ত্রুটি",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "স্ট্রিমিং সার্ভারের URL কনফিগার করুন",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "একটি স্ট্রিমিং সার্ভারের URL প্রবেশ করান",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "ক্যাশের আকার",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "টরেন্ট প্রোফাইল",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ca-ES.json
+++ b/ca-ES.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configura l'URL del servidor de transmissió",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Introdueix l'URL d'un servidor de transmissió",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Mida de la memòria cau",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Perfil de Torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Executa en segon pla",

--- a/cs-CZ.json
+++ b/cs-CZ.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Nastavení URL streamovacího serveru",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Zadejte adresu URL streamovacího serveru",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Velikost mezipaměti",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil torrentu",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Nechat běžet na pozadí",

--- a/da-DK.json
+++ b/da-DK.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Fejl",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfigurer streamingserverens URL",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Indtast en streamingserverens URL",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cachestørrelse",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent-profil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Kør i baggrunden",

--- a/de-DE.json
+++ b/de-DE.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Fehler",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Streaming-Server-URL konfigurieren",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Geben Sie eine Streaming-Server-URL ein",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Zwischenspeicher-Größe",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent-Profil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Im Hintergrund ausführen",

--- a/el-GR.json
+++ b/el-GR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Προέκυψε σφάλμα",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Διαμορφώστε το URL του διακομιστή αναπαραγωγής",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Εισαγωγή ενός URL διακομιστή αναπαραγωγής",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Μέγεθος επιτρεπόμενης μνήμης cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Προφίλ torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Εκτέλεση στο παρασκήνιο",

--- a/en-US.json
+++ b/en-US.json
@@ -664,6 +664,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server URL",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server URL",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/eo-EO.json
+++ b/eo-EO.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/es-ES.json
+++ b/es-ES.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configurar url del servidor de transmisión",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Ingrese url del servidor de transmisión",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Tamaño de caché",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Perfil de torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Ejecutar en segundo plano",

--- a/et-EE.json
+++ b/et-EE.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Viga",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Seadista voogesituse serveri URL",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Sisesta voogesituse serveri URL",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Vahemälu suurus",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrentiprofiil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/eu-ES.json
+++ b/eu-ES.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Streaming zerbitzariaren URLa sartu",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache tamaina",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profila",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/fa-IR.json
+++ b/fa-IR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "خطا",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "پیکربندی آدرس سرور استریم",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "وارد کردن URL سرور استریم",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "اندازه کش",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "پروفایل تورنت",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "اجرای در پس‌زمینه",

--- a/fi-FI.json
+++ b/fi-FI.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Virhe",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Määritä suoratoistopalvelimen URL-osoite",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Syötä suoratoistopalvelimen URL-osoite",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Välimuistin koko",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent-profiili",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/fr-FR.json
+++ b/fr-FR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Erreur",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configurer l’URL du serveur de streaming",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Entrez l’URL du serveur de streaming",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Taille du cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil de torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Exécuter en arrière-plan",

--- a/he-IL.json
+++ b/he-IL.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "שגיאה",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "הגדר את כתובת האתר של שרת ההזרמה",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "הזן כתובת אתר של שרת ההזרמה",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "גודל המטמון",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "פרופיל הטורנט",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/hi-IN.json
+++ b/hi-IN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/hr-HR.json
+++ b/hr-HR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Pogreška",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfiguriraj URL streaming poslužitelja",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Unesite URL streaming poslužitelja",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Veličina predmemorije",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/hu-HU.json
+++ b/hu-HU.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Hiba",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "A streaming szerver URL-jének konfigurálása",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Adja meg a streaming szerver URL-címét",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Gyorsítótár mérete",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/id-ID.json
+++ b/id-ID.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfigurasi URL server streaming",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Masukkan URL server streaming",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Ukuran cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/it-IT.json
+++ b/it-IT.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Errore",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configura URL del server di riproduzione",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Inserisci URL del server di riproduzione",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Dimensione cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profilo torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ja-JP.json
+++ b/ja-JP.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "エラー",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "ストリーミングサーバーのURLを設定",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "ストリーミングサーバーのURLを入力",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "キャッシュサイズ",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "トレントプロファイル",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ko-KR.json
+++ b/ko-KR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/lt-LT.json
+++ b/lt-LT.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Klaida",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfigūruoti transliavimo serverio URL nuorodą",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Įveskite transliavimo serverio URL nuorodą",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Talpyklos (Cache) dydis",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torentų profilis",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/mk-MK.json
+++ b/mk-MK.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Грешка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Конфигурирај URL-адреса на серверот за стриминг",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Внеси URL-адреса на серверот за стриминг",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Големина на кешот",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Торент профил",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/my-BM.json
+++ b/my-BM.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/nb-NO.json
+++ b/nb-NO.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ne-NP.json
+++ b/ne-NP.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/nl-NL.json
+++ b/nl-NL.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Fout",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configureer streamingserver-URL",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Voer een streamingserver-URL in",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cachegrootte",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrentprofiel",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Op de achtergrond uitvoeren",

--- a/nn-NO.json
+++ b/nn-NO.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/pa-IN.json
+++ b/pa-IN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/pl-PL.json
+++ b/pl-PL.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Błąd",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfiguracja adresu URL serwera streamingowego",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Wprowadź adres URL serwera streamingowego",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Rozmiar pamięci podręcznej",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/pt-BR.json
+++ b/pt-BR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Erro",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configurar URL do servidor de streaming",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Insira a URL do servidor de streaming",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Tamanho do cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Perfil de torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Executar em segundo plano",

--- a/pt-PT.json
+++ b/pt-PT.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Erro",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configurar o URL do servidor de streaming",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Introduz um URL de servidor de streaming",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Tamanho da cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Perfil do torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Executar em segundo plano",

--- a/ro-RO.json
+++ b/ro-RO.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Eroare",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configurați URL-ul serverului de streaming",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Introduceți un URL pentru serverul de streaming",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Dimensiune cache",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Rulează în fundal",

--- a/ru-RU.json
+++ b/ru-RU.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Ошибка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Настроить URL сервера стриминга",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Введите URL сервера стриминга",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Размер кэша",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Профиль торрента",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/sk-SK.json
+++ b/sk-SK.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Chyba",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Nastavenie URL stream servera",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Zadajte URL stream servera",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Veľkosť vyrovnávacej pamäte",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Profil torrentu",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Spustiť na pozadí",

--- a/sl-SL.json
+++ b/sl-SL.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/sr-RS.json
+++ b/sr-RS.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Грешка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Конфигурација URL-а сервера за стримовање",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Унесите URL сервера за стримовање ",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Величина кеша",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Торент профил",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/sv-SE.json
+++ b/sv-SE.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Fel",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Konfigurera webbadress för strömningsserver",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Ange en webbadress till en strömningsserver",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cachestorlek",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent-profil",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ta-IN.json
+++ b/ta-IN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "பிழை",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "ஸ்ட்ரீமிங் சேவையக URL-ஐ கட்டமை",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "ஒரு ஸ்ட்ரீமிங் சேவையக URL-ஐ உள்ளிடவும்",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "தற்காலிக சேமிப்பு அளவு",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "டொரண்ட் சுயவிவரம்",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/te-IN.json
+++ b/te-IN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Error",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Configure streaming server url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Enter a streaming server url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Cache size",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profile",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/tr-TR.json
+++ b/tr-TR.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Hata",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Yayın akış sunucusu URL'sini yapılandırın",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Bir yayın akış sunucusu URL'si girin",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Önbellek boyutu",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent profili",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Arka planda çalıştır",

--- a/uk-UA.json
+++ b/uk-UA.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Помилка",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Налаштувати URL-адресу потокового сервера",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Введіть URL-адресу потокового сервера",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Розмір кешу",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Торент профіль",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/ur-PK.json
+++ b/ur-PK.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "خرابی",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "سٹریمنگ سرور url کنفیگر کریں",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "سٹریمنگ سرور url داخل کریں",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "کیش سائز",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "ٹورنٹ پروفائل",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/vi-VN.json
+++ b/vi-VN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "Lỗi",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "Định cấu hình url máy chủ truyền trực tuyến",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "Nhập url máy chủ truyền trực tuyến",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "Kích thước bộ nhớ đệm",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Hồ sơ torrent",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/zh-CN.json
+++ b/zh-CN.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "错误",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "配置流媒体服务器url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "输入流媒体服务器url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "缓存大小",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent配置",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/zh-HK.json
+++ b/zh-HK.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "錯誤",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "配置流媒體服務器url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "輸入流媒體服務器url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "緩存大小",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent配置",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -660,6 +660,7 @@
 	"SETTINGS_SERVER_STATUS_ERROR": "錯誤",
 	"SETTINGS_SERVER_CONFIGURE_TITLE": "配置流媒體伺服器url",
 	"SETTINGS_SERVER_CONFIGURE_INPUT": "輸入流媒體伺服器url",
+	"SETTINGS_SERVER_CONFIGURE_CONFIRM": "Do you want to use this streaming server? Only continue if you trust this address.",
 	"SETTINGS_SERVER_CACHE_SIZE": "快取大小",
 	"SETTINGS_SERVER_TORRENT_PROFILE": "Torrent配置",
 	"SETTINGS_SERVER_RUN_IN_BACKGROUND": "Run in the background",


### PR DESCRIPTION
Confirmation message for the streaming server URL dialog in stremio-web.

Added after `SETTINGS_SERVER_CONFIGURE_INPUT` in all 51 files with the English value, so the key order stays aligned with `en-US.json`.